### PR TITLE
Kc/arrange imfd

### DIFF
--- a/Preprocessing/Arrange_IMFD_Images.ipynb
+++ b/Preprocessing/Arrange_IMFD_Images.ipynb
@@ -4,7 +4,8 @@
   "metadata": {
     "colab": {
       "name": "Arrange_IMFD_Images.ipynb",
-      "provenance": []
+      "provenance": [],
+      "collapsed_sections": []
     },
     "kernelspec": {
       "name": "python3",
@@ -59,9 +60,10 @@
       "source": [
         "import os\n",
         "import ntpath\n",
-        "import random"
+        "import random\n",
+        "import shutil"
       ],
-      "execution_count": 28,
+      "execution_count": 36,
       "outputs": []
     },
     {
@@ -71,14 +73,20 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "19BRMUOQWD-i",
-        "outputId": "c1967dc7-d0e8-4360-fb90-7abfa5d5aa98"
+        "outputId": "00060394-ebad-4290-f6fd-2eef1addfd47"
       },
       "source": [
         "IMFD_DIR = '/content/drive/MyDrive/capstone_machine_learning/capstone_dataset/IMFD' # Change based on dataset dir on your system/device\n",
-        "DEST_DIR = '/content/drive/MyDrive/capstone_machine_learning/capstone_dataset/IMFD' # Change based on dataset dir on your system/device\n",
+        "DEST_DIR = '/content/drive/MyDrive/capstone_machine_learning/capstone_dataset/arranged_dataset' # Change based on dataset dir on your system/device\n",
+        "\n",
+        "# Size for each label\n",
+        "TRAIN_SIZE = 2000\n",
+        "VAL_SIZE = 400\n",
+        "TEST_SIZE = 400\n",
+        "\n",
         "os.listdir(IMFD_DIR)"
       ],
-      "execution_count": 5,
+      "execution_count": 33,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -159,7 +167,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 5
+          "execution_count": 33
         }
       ]
     },
@@ -283,7 +291,20 @@
         "id": "p_zHd8TPgZQP"
       },
       "source": [
-        "## Sampling each shuffled lists into destination directories."
+        "## Sampling each shuffled lists into destination directories.\n",
+        "\n",
+        "After we get lists of paths for each labels, we need to do sampling and copy sampled images to new directories. There are 1 directory for each label, i.e. `uncovered_chin/` for `uncov_chin_paths`, `uncovered_nose/` for `uncov_nose_paths`, and `uncovered_nose_and_mouth` for `uncov_nose_mouth_paths`.\n",
+        "\n",
+        "There are 3 sets of these label directories, each for `training/`, `validation/`, and `testing/`. `training/`, `validation/`, and `testing/` should be found in `DEST_DIR`. `TRAIN_SIZE`, `VAL_SIZE`, and `TEST_SIZE` determine how many data in each path list are distributed to the `training/`, `validation/`, and `testing/`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Ik0iAbY2iJot"
+      },
+      "source": [
+        "First we need a function to easily extract file name from a full path. This is used for appending file name to new directory path for copying."
       ]
     },
     {
@@ -310,12 +331,12 @@
           "height": 35
         },
         "id": "TKVJf1O7fDcu",
-        "outputId": "cf766a96-769b-4f69-fd88-0641046eee67"
+        "outputId": "22c85939-6722-4f7c-ab01-7d8b667e5252"
       },
       "source": [
-        "get_path_leaf(uncov_chin_paths[536])"
+        "get_path_leaf(uncov_chin_paths[0])"
       ],
-      "execution_count": 30,
+      "execution_count": 31,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -324,20 +345,183 @@
               "type": "string"
             },
             "text/plain": [
-              "'05474_Mask_Nose_Mouth.jpg'"
+              "'04544_Mask_Nose_Mouth.jpg'"
             ]
           },
           "metadata": {
             "tags": []
           },
-          "execution_count": 30
+          "execution_count": 31
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZrN-HFv44Wy1"
+      },
+      "source": [
+        "Now we make a function to copy files in a list into a new directory. This function copies into only a single directory from list of many paths."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "G76VyW-ok2zw"
+      },
+      "source": [
+        "def copy_list_of_files(list_of_paths, dest_dir):\n",
+        "  try:\n",
+        "    for img in list_of_paths:\n",
+        "      name = get_path_leaf(img)\n",
+        "      shutil.copy2(img, os.path.join(dest_dir, name))\n",
+        "    return True\n",
+        "  except Exception as err:\n",
+        "    print(err)\n",
+        "    return False"
+      ],
+      "execution_count": 37,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ch_RriCHiX6j"
+      },
+      "source": [
+        "Because we already shuffle the lists. We can just pick the first n elements of each lists. Then we copy subset of each lists to corresponding new directories using previously created function."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "cXKLxJKNfIZL",
+        "outputId": "7e776ed0-a33f-47e8-bdf3-2140af292bb8"
+      },
+      "source": [
+        "LABELS = ['uncovered_chin', 'uncovered_nose', 'uncovered_nose_and_mouth']\n",
+        "lists = [uncov_chin_paths, uncov_nose_paths, uncov_nose_mouth_paths]\n",
+        "for i, lst in enumerate(lists):\n",
+        "  # train = lst[:TRAIN_SIZE]\n",
+        "  val = lst[TRAIN_SIZE : TRAIN_SIZE+VAL_SIZE]\n",
+        "  test = lst[TRAIN_SIZE+VAL_SIZE : TRAIN_SIZE+VAL_SIZE+TEST_SIZE]\n",
+        "  label = LABELS[i]\n",
+        "\n",
+        "  # train_dest = os.path.join(DEST_DIR, 'train', label)\n",
+        "  val_dest = os.path.join(DEST_DIR, 'validation', label)\n",
+        "  test_dest = os.path.join(DEST_DIR, 'test', label)\n",
+        "\n",
+        "  # print(f'Copying to \\\"train/{label}\\\" success:', copy_list_of_files(train, train_dest))\n",
+        "  print(f'Copying to \\\"validation/{label}\\\" success:', copy_list_of_files(val, val_dest))\n",
+        "  print(f'Copying to \\\"test/{label}\\\" success:', copy_list_of_files(test, test_dest))"
+      ],
+      "execution_count": 44,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Copying to \"validation/uncovered_chin\" success: True\n",
+            "Copying to \"test/uncovered_chin\" success: True\n",
+            "Copying to \"validation/uncovered_nose\" success: True\n",
+            "Copying to \"test/uncovered_nose\" success: True\n",
+            "Copying to \"validation/uncovered_nose_and_mouth\" success: True\n",
+            "Copying to \"test/uncovered_nose_and_mouth\" success: True\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "U7_cAg-wCtrh"
+      },
+      "source": [
+        "## Debug"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "jgUZH-E3jldn",
+        "outputId": "7b17a76f-1398-4a5c-f6c5-a0170df00e83"
+      },
+      "source": [
+        "# Debug file count in each folder\n",
+        "summ = 0\n",
+        "for i in os.listdir(DEST_DIR):\n",
+        "  for j in os.listdir(os.path.join(DEST_DIR, i)):\n",
+        "    length = len(os.listdir(os.path.join(DEST_DIR, i, j)))\n",
+        "    summ += length\n",
+        "    print(i, j, length)\n",
+        "\n",
+        "print(summ)"
+      ],
+      "execution_count": 50,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "train correctly_masked 0\n",
+            "train uncovered_chin 2000\n",
+            "train uncovered_nose 2000\n",
+            "train uncovered_nose_and_mouth 2000\n",
+            "train no_mask 0\n",
+            "validation uncovered_chin 400\n",
+            "validation uncovered_nose 400\n",
+            "validation correctly_masked 0\n",
+            "validation uncovered_nose_and_mouth 400\n",
+            "validation no_mask 0\n",
+            "test uncovered_chin 400\n",
+            "test correctly_masked 0\n",
+            "test uncovered_nose 400\n",
+            "test uncovered_nose_and_mouth 400\n",
+            "test no_mask 0\n",
+            "8400\n"
+          ],
+          "name": "stdout"
         }
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "cXKLxJKNfIZL"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "qVjWuKG9DGtH",
+        "outputId": "7fa1c365-692d-405a-a83e-26988b3aad69"
+      },
+      "source": [
+        "# Debug unique file names to check no duplication\n",
+        "all_set = set()\n",
+        "for i in os.listdir(DEST_DIR):\n",
+        "  for j in os.listdir(os.path.join(DEST_DIR, i)):\n",
+        "    all_set = set.union(all_set, set(os.listdir(os.path.join(DEST_DIR, i, j))))\n",
+        "\n",
+        "print(len(all_set))"
+      ],
+      "execution_count": 51,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "8400\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "rsAFHFHBEShG"
       },
       "source": [
         ""

--- a/Preprocessing/Arrange_IMFD_Images.ipynb
+++ b/Preprocessing/Arrange_IMFD_Images.ipynb
@@ -1,0 +1,349 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Arrange_IMFD_Images.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "A3qvDBNTVDZr"
+      },
+      "source": [
+        "# Arranging Incorrectly Masked Face Dataset (IMFD)\n",
+        "\n",
+        "This notebook would split __IMFD__ images based on their sub-labels, \"__uncovered chin__\", \"__uncovered nose__\", and \"__uncovered nose and mouth__\". These splitted images would then be sampled and copied to new directories to be feed into __tf.keras.preprocessing.image.ImageDataGenerator__."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "1ZWVtYFhQKCg",
+        "outputId": "a333aba5-ce07-4f38-9ea8-0e0a1019bf3a"
+      },
+      "source": [
+        "from google.colab import drive\n",
+        "\n",
+        "drive.mount('/content/drive')"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Mounted at /content/drive\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Nrqu6GEkUi7p"
+      },
+      "source": [
+        "import os\n",
+        "import ntpath\n",
+        "import random"
+      ],
+      "execution_count": 28,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "19BRMUOQWD-i",
+        "outputId": "c1967dc7-d0e8-4360-fb90-7abfa5d5aa98"
+      },
+      "source": [
+        "IMFD_DIR = '/content/drive/MyDrive/capstone_machine_learning/capstone_dataset/IMFD' # Change based on dataset dir on your system/device\n",
+        "DEST_DIR = '/content/drive/MyDrive/capstone_machine_learning/capstone_dataset/IMFD' # Change based on dataset dir on your system/device\n",
+        "os.listdir(IMFD_DIR)"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "['00000',\n",
+              " '01000',\n",
+              " '02000',\n",
+              " '03000',\n",
+              " '04000',\n",
+              " '05000',\n",
+              " '06000',\n",
+              " '07000',\n",
+              " '08000',\n",
+              " '09000',\n",
+              " '10000',\n",
+              " '11000',\n",
+              " '12000',\n",
+              " '13000',\n",
+              " '14000',\n",
+              " '15000',\n",
+              " '16000',\n",
+              " '17000',\n",
+              " '18000',\n",
+              " '19000',\n",
+              " '20000',\n",
+              " '21000',\n",
+              " '22000',\n",
+              " '23000',\n",
+              " '24000',\n",
+              " '25000',\n",
+              " '26000',\n",
+              " '27000',\n",
+              " '28000',\n",
+              " '29000',\n",
+              " '30000',\n",
+              " '31000',\n",
+              " '32000',\n",
+              " '33000',\n",
+              " '34000',\n",
+              " '35000',\n",
+              " '36000',\n",
+              " '37000',\n",
+              " '38000',\n",
+              " '39000',\n",
+              " '40000',\n",
+              " '41000',\n",
+              " '42000',\n",
+              " '43000',\n",
+              " '44000',\n",
+              " '45000',\n",
+              " '46000',\n",
+              " '47000',\n",
+              " '48000',\n",
+              " '49000',\n",
+              " '50000',\n",
+              " '51000',\n",
+              " '52000',\n",
+              " '53000',\n",
+              " '54000',\n",
+              " '55000',\n",
+              " '56000',\n",
+              " '57000',\n",
+              " '58000',\n",
+              " '59000',\n",
+              " '60000',\n",
+              " '61000',\n",
+              " '62000',\n",
+              " '63000',\n",
+              " '64000',\n",
+              " '65000',\n",
+              " '66000',\n",
+              " '67000',\n",
+              " '68000',\n",
+              " '69000']"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 5
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AcQfjzPiX_ji"
+      },
+      "source": [
+        "## Splitting the three sub-labels\n",
+        "\n",
+        "IMFD directory doesn't directly has the images as direct children. They are subfoldered into 70 subfolders of ~1000 images, i.e. \"00000/\", \"01000/\", \"02000/\", etc. So to get all the IMFD images, we need to traverse in each of IMFD's subfolders.\n",
+        "\n",
+        "So the idea here is to list all the images names in all subfolders, then split them to three `lists` based on the name. \"Mask_Nose_Mouth\" would go to `uncov_chin_paths`, \"Mask_Mouth_Chin\" would go to `uncov_nose_paths`, and \"Mask_Chin\" would go to `uncov_nose_mouth_paths`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "m86S1lbZWmdi",
+        "outputId": "a6f76101-e3cd-4111-b4c3-e656befbc4d2"
+      },
+      "source": [
+        "uncov_chin_paths = []\n",
+        "uncov_nose_paths = []\n",
+        "uncov_nose_mouth_paths = []\n",
+        "\n",
+        "for child in os.listdir(IMFD_DIR):\n",
+        "  child_path = os.path.join(IMFD_DIR, child)\n",
+        "  if os.path.isdir(child_path):\n",
+        "    # print(child, len(os.listdir(child_path)))\n",
+        "    # print(os.listdir(child_path))\n",
+        "    for img in os.listdir(child_path):\n",
+        "      img_path = os.path.join(child_path, img)\n",
+        "      if 'Mask_Nose_Mouth' in img:\n",
+        "        uncov_chin_paths.append(img_path)\n",
+        "      elif 'Mask_Mouth_Chin' in img:\n",
+        "        uncov_nose_paths.append(img_path)\n",
+        "      elif 'Mask_Chin' in img:\n",
+        "        uncov_nose_mouth_paths.append(img_path)\n",
+        "      \n",
+        "print('Count of uncovered chin:', len(uncov_chin_paths))\n",
+        "print('Count of uncovered nose:', len(uncov_nose_paths))\n",
+        "print('Count of uncovered nose and mouth:', len(uncov_nose_mouth_paths))"
+      ],
+      "execution_count": 18,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Count of uncovered chin: 6245\n",
+            "Count of uncovered nose: 55653\n",
+            "Count of uncovered nose and mouth: 4836\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "bes8e-mXYuMp",
+        "outputId": "9ae3df1b-94cd-4bbd-a03c-0d0fdf9f2b48"
+      },
+      "source": [
+        "# Debug splitted lists percentages\n",
+        "len_chin = len(uncov_chin_paths)\n",
+        "len_nose = len(uncov_nose_paths)\n",
+        "len_nose_mouth = len(uncov_nose_mouth_paths)\n",
+        "summ = len_chin + len_nose + len_nose_mouth\n",
+        "print('Total IMFD images:', summ)\n",
+        "print('Percentage of uncovered chin:', len_chin *100 / summ)\n",
+        "print('Percentage of uncovered nose:', len_nose *100 / summ)\n",
+        "print('Percentage of uncovered nose and mouth:', len_nose_mouth *100 / summ)"
+      ],
+      "execution_count": 20,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Total IMFD images: 66734\n",
+            "Percentage of uncovered chin: 9.358048371145143\n",
+            "Percentage of uncovered nose: 83.39527077651572\n",
+            "Percentage of uncovered nose and mouth: 7.2466808523391375\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Afmqp9GBfeQz"
+      },
+      "source": [
+        "To avoid potential ordering biases, we shuffle the lists."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "bVeG_ovifqis"
+      },
+      "source": [
+        "random.shuffle(uncov_chin_paths)\n",
+        "random.shuffle(uncov_nose_paths)\n",
+        "random.shuffle(uncov_nose_mouth_paths)"
+      ],
+      "execution_count": 29,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "p_zHd8TPgZQP"
+      },
+      "source": [
+        "## Sampling each shuffled lists into destination directories."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "q-HK805yeTT_"
+      },
+      "source": [
+        "def get_path_leaf(path):\n",
+        "  '''\n",
+        "  Taken from https://stackoverflow.com/questions/8384737/extract-file-name-from-path-no-matter-what-the-os-path-format\n",
+        "  '''\n",
+        "  head, tail = ntpath.split(path)\n",
+        "  return tail or ntpath.basename(head)"
+      ],
+      "execution_count": 23,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        },
+        "id": "TKVJf1O7fDcu",
+        "outputId": "cf766a96-769b-4f69-fd88-0641046eee67"
+      },
+      "source": [
+        "get_path_leaf(uncov_chin_paths[536])"
+      ],
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            },
+            "text/plain": [
+              "'05474_Mask_Nose_Mouth.jpg'"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 30
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "cXKLxJKNfIZL"
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Added notebook to arrange IMFD images into train, validation, and test, each further splitted into three labels: "uncovered chin", "uncovered nose", and "uncovered nose and mouth".